### PR TITLE
Implement Row Grey Out using foreground rather than background colour

### DIFF
--- a/Default.css
+++ b/Default.css
@@ -68,6 +68,12 @@ th
     width:100%;
 }
 
+.tdTestClassLargeGreyOut 
+{
+    color:#888888;
+    width:100%;
+}
+
 .thTestClassLarge 
 {
     background-color:Navy;
@@ -75,32 +81,17 @@ th
     width:100%;
 }
 
-.trTestClassLarge
-{
-    min-height:30px;
-    background-color:White;
-}
+.trTestClassLarge,
+.trTestClassLargeOdd,
+.trTestClassLargeEven,
+.trSelectedTestClassLarge
+{ min-height:30px; }
 
-.trTestClassLargeOdd
-{
-    min-height:30px;
-    background-color:#FAC5F2;
-}
 
-.trTestClassLargeEven
-{
-    min-height:30px;
-    background-color:#D3C5FA;
-}
+.trTestClassLarge { background-color:White;}
 
-.trTestClassLargeGreyOut
-{
-    background-color:#CCCCCC;
-    /* color:#AAAAAA !important; */ /* Cannot set foreground color by row, only background color */
-}
+.trTestClassLargeOdd { background-color:#FAC5F2; }
 
-.trSelectedTestClassLarge 
-{
-    min-height:30px;
-    background-color:#FCFB8B;
-}
+.trTestClassLargeEven { background-color:#D3C5FA; }
+
+.trSelectedTestClassLarge { background-color:#FCFB8B; }

--- a/js/Default.js
+++ b/js/Default.js
@@ -45,7 +45,7 @@ kawasu.orders.init = function () {
 
     // If you set a grey out class, you can use the greyRows() function to grey
     // out rows that match data values in a certain column
-    styleDefn["trClassGreyOut"] = "trTestClassLargeGreyOut";
+    styleDefn["tdClassGreyOut"] = "tdTestClassLargeGreyOut"; // Cell style grey out - text
 
     // BUILD A TEST DATA SET
     var arrData = kawasu.orders.createTestDataA();

--- a/js/DynaTable.js
+++ b/js/DynaTable.js
@@ -1039,8 +1039,8 @@ kawasu.dynatable.greyRows = function (sTableId, sColumnName, sColumnData, bGreyO
     // Default Syntax; This defaults to true, grey out the row
     bGreyOut = (typeof bGreyOut === 'undefined') ? true : bGreyOut;
 
-    if (!kawasu.dynatable[sTableId]["styleDefn"].hasOwnProperty("trClassGreyOut")) {
-        console.log(prefix + "WARNING: No trClassGreyOut style is set in the style definition for this table; No action taken.");
+    if (!kawasu.dynatable[sTableId]["styleDefn"].hasOwnProperty("tdClassGreyOut")) {
+        console.log(prefix + "WARNING: No tdClassGreyOut style is set in the style definition for this table; No action taken.");
         return;
     }
 
@@ -1048,7 +1048,9 @@ kawasu.dynatable.greyRows = function (sTableId, sColumnName, sColumnData, bGreyO
     ///////////////////////////////////////////////////////////////////////////
     // Grey out the rows where the passed column matches the passed data string
 
-    var trClassGreyOut = kawasu.dynatable[sTableId]["styleDefn"]["trClassGreyOut"];
+    var tdClassGreyOut = kawasu.dynatable[sTableId]["styleDefn"]["tdClassGreyOut"];
+    var tdClass = kawasu.dynatable[sTableId]["styleDefn"]["tdClass"];
+
     var rows = kawasu.dynatable.getRows(sTableId, sColumnName, sColumnData);
     if (typeof rows === 'undefined' || rows.length == 0) {
         console.log(prefix + "WARNING: No rows found matching the criteria");
@@ -1058,17 +1060,21 @@ kawasu.dynatable.greyRows = function (sTableId, sColumnName, sColumnData, bGreyO
     for (var i = 0; i < rows.length; ++i) {
         row = rows[i];
         if (bGreyOut) {
-            row.className = row.className + " " + trClassGreyOut;
+            kawasu.dynatable.setCellClass(row,tdClassGreyOut); // Set Grey
         }
         else {
-            kawasu.dynatable.setRowDeselected(sTableId, row, row.rowIndex);
-            // Note, rowIndex should be the index of the row in the table, not 
-            // the index of the row in the array returned from getRows().
+            kawasu.dynatable.setCellClass(row,tdClass); // Set Normal
         }
     }
 
     console.log(prefix + "Exiting");
     return rows; // caller may interrogate returned rows, saves recalling getRows() again
+}
+
+kawasu.dynatable.setCellClass = function (row, sClass) {
+    for (var i = 0; i < row.cells.length; ++i) {
+        row.cells[i].className = sClass;
+    }
 }
 
 kawasu.dynatable.getRows = function (sTableId, sColumnName, sColumnData) {


### PR DESCRIPTION
CHANGED: greyRows() fn to use cell rather than row changes
ADDED: setCellClass() fn to switch row's cell class
CSS: Add cell grey out style, remove row grey out style, refactored
CHANGED: StyleDefn now has tdClassGreyOut as entry, not trClassGreyOut
