### PR TITLE
Cell widths now set only on first row of table (Performance fix);

### DIFF
--- a/Default.css
+++ b/Default.css
@@ -8,7 +8,7 @@
 {
     overflow:hidden;
     background-color:#EEEEEE;
-    width:200px; 
+    width:800px; 
 }
 
 

--- a/js/Default.js
+++ b/js/Default.js
@@ -48,11 +48,12 @@ kawasu.orders.init = function () {
     styleDefn["tdClassGreyOut"] = "tdTestClassLargeGreyOut"; // Cell style grey out - text
 
     // BUILD A TEST DATA SET
-    var arrData = kawasu.orders.createTestDataA();
+    var arrDataA = kawasu.orders.createTestDataA();
+    
 
     // Dynatable testing
     var myDynaTable = kawasu.dynatable.build(
-        arrData,
+        arrDataA,
         styleDefn,
         "myDynaTable",
         10,
@@ -62,13 +63,13 @@ kawasu.orders.init = function () {
     $("#divContainer").append(myDynaTable);
 
     // BUILD A 2ND TEST DATA SET
-    var arrDataB = kawasu.orders.createTestDataB();
+    //var arrDataB = kawasu.orders.createTestDataB();
+    var arrDataB = kawasu.orders.createTestDataLargeRandom();
     kawasu.dynatable.rebuild("myDynaTable", arrDataB);
 
     kawasu.orders.hookupHandlers();
 
     kawasu.orders.btnToggleMultiSelect_setBtnText();
-
 
     console.log(prefix + "Exiting");
 }
@@ -194,11 +195,11 @@ kawasu.orders.createTestDataLargeRandom = function () {
     // Make a Json object to build a table out of
     var array = [];
 
-    for (var j = 0; j < 10000; ++j) {
+    for (var j = 0; j < 1000; ++j) {
         var obj = new Object();
-        for (var i = 0; i < 20; ++i) {
+        for (var i = 0; i < 50; ++i) {
             var sProp = "Property" + (i.toString());
-            obj[sProp] = i.toString();
+            obj[sProp] = kawasu.orders.getRandomString(32);
         }
         array.push(obj);
     }
@@ -206,6 +207,16 @@ kawasu.orders.createTestDataLargeRandom = function () {
     return array;
 
     console.log(prefix + "Exiting");
+}
+
+kawasu.orders.getRandomString = function (nStringLength) {
+    var nRandom = (Math.random() + 1); // 1.1234563443
+    var sRandom = nRandom.toString(36); // "1.garbage"
+    sRandom = sRandom.substring(2, sRandom.length); // drop first 2 chars ie "1."
+    if (fc.utils.isValidVar(nStringLength) && nStringLength > 0) {
+        sRandom = sRandom.substring(0, nStringLength);
+    }
+    return sRandom;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/js/DynaTable.js
+++ b/js/DynaTable.js
@@ -253,7 +253,10 @@ kawasu.dynatable.buildScrollingTable = function (table, nRowsToShow, bExtendLast
     var sTableId = table.id;
 
     table.style.tableLayout = "auto";
-    var arrayColumnWidths = kawasu.dynatable.getTableColumnWidths(table);
+
+    // Calculate and Store column widths
+    kawasu.dynatable[table.id].arrayColumnWidths = kawasu.dynatable.getTableColumnWidths(table);
+
     var sizeTable = kawasu.dynatable.getTableSize(table); // This is the size before the table is cut in two
 
     // Clone the table to make a header only
@@ -285,8 +288,8 @@ kawasu.dynatable.buildScrollingTable = function (table, nRowsToShow, bExtendLast
     tableHeader.style.tableLayout = "fixed";
     var maxTableWidth = sizeTable.width;
     tableHeader.style.width = table.style.width = maxTableWidth.toString() + "px";
-    kawasu.dynatable.setTableColumnWidths(table, arrayColumnWidths);
-    kawasu.dynatable.setTableColumnWidths(tableHeader, arrayColumnWidths);
+    kawasu.dynatable.setTableColumnWidths(table, kawasu.dynatable[table.id].arrayColumnWidths);
+    kawasu.dynatable.setTableColumnWidths(tableHeader, kawasu.dynatable[table.id].arrayColumnWidths);
 
     // Get scrollbar dimensions
     var sbWidth = fc.utils.getScrollBarWidth();
@@ -464,10 +467,10 @@ kawasu.dynatable.setTableColumnWidths = function (table, arrayColumnWidths) {
     if (kawasu.dynatable.config.bLog) console.log(prefix + "Entering");
 
     // Iterate the table and set width settings for each cell
-    for (var i = 0; i < table.rows.length; ++i) {
-        for (var j = 0; j < table.rows[i].cells.length; ++j) {
+    if (table.rows.length > 0) {
+        for (var j = 0; j < table.rows[0].cells.length; ++j) {
             var width = arrayColumnWidths[j] || 0;
-            table.rows[i].cells[j].style.width = width.toString() + "px";
+            table.rows[0].cells[j].style.width = width.toString() + "px";
         }
     }
 
@@ -747,7 +750,11 @@ kawasu.dynatable.sortrows = function (table, tableHeader, n, comparator) {
         table.appendChild(rowsBlank[i][0]);
     }
 
+    // Re-apply the zebra striping
     kawasu.dynatable.resetRows(sTableId, table, true);
+
+    // Set the column widths of what is now the first row
+    kawasu.dynatable.setTableColumnWidths(table, kawasu.dynatable[table.id].arrayColumnWidths);
 
     // Save the sort column and order
     var sortColCName = table.id + "_SortCol";

--- a/js/FCUtils.js
+++ b/js/FCUtils.js
@@ -63,6 +63,11 @@ fc.utils.isEmptyString = function(obj) {
     return false;
 }
 
+//fc.utils.isNotEmptyStringOrWhiteSpace = function (str) {
+//    str = str.replace(/\s+/g, "");
+//    return str.length == 0 ? false : true;
+//}
+
 fc.utils.isEmptyStringOrWhiteSpace = function (obj) {
 
     if (fc.utils.isInvalidVar(obj))
@@ -1221,8 +1226,9 @@ fc.utils.isBlankRow = function (row) {
     var bRowIsBlank = true;
     for (var i = 0; (i < countCells && bRowIsBlank == true); ++i) {
         var sCell = row.cells[i].innerHTML;
-        if (!fc.utils.isEmptyStringOrWhiteSpace(sCell))
+        if (!fc.utils.isEmptyStringOrWhiteSpace(sCell)) {
             bRowIsBlank = false;
+        }
     }
     return bRowIsBlank;
 }
@@ -1340,11 +1346,14 @@ fc.utils.numericComparator = function (val1, val2) {
     */
 
     // Null or Empty String Handling
-    if (fc.utils.isEmptyStringOrWhiteSpace(val1) && fc.utils.isEmptyStringOrWhiteSpace(val2))
+    var bVal1Empty = fc.utils.isEmptyStringOrWhiteSpace(val1);
+    var bVal2Empty = fc.utils.isEmptyStringOrWhiteSpace(val2);
+
+    if (bVal1Empty && bVal2Empty)
         return 0;
-    if (fc.utils.isEmptyStringOrWhiteSpace(val1))
+    if (bVal1Empty)
         return -1;
-    if (fc.utils.isEmptyStringOrWhiteSpace(val2))
+    if (bVal2Empty)
         return 1;
     // else we have two non-white space strings
 
@@ -1373,23 +1382,17 @@ fc.utils.numericComparator = function (val1, val2) {
 
 fc.utils.defaultComparator = function (val1, val2) {
 
-    /*
-    // Null handling
-    if (val1 == null && val2 == null)
-    return 0;
-    if (val1 == null) // and implicitly, val2 is not null, val2 is greater, return -1
-    return -1;
-    if (val2 == null) // and implicitly, val1 is not null, val1 is greater, return 1
-    return 1;
-    // else, we have two valid strings
-    */
-
     // Null or Empty String Handling
-    if (fc.utils.isEmptyStringOrWhiteSpace(val1) && fc.utils.isEmptyStringOrWhiteSpace(val2))
+    var bVal1Empty = fc.utils.isEmptyStringOrWhiteSpace(val1);
+    var bVal2Empty = fc.utils.isEmptyStringOrWhiteSpace(val2);
+    //var bVal1Empty = !fc.utils.isNotEmptyStringOrWhiteSpace(val1);
+    //var bVal2Empty = !fc.utils.isNotEmptyStringOrWhiteSpace(val2);
+
+    if (bVal1Empty && bVal2Empty)
         return 0;
-    if (fc.utils.isEmptyStringOrWhiteSpace(val1))
+    if (bVal1Empty)
         return -1;
-    if (fc.utils.isEmptyStringOrWhiteSpace(val2))
+    if (bVal2Empty)
         return 1;
     // else we have two non-white space strings
 


### PR DESCRIPTION
CHANGED: DynaTable.js
- Column widths are now stored in a variable for the table, for post-sort re-application.
- Only first row of the table has widths applied to cells.

CHANGED: FCUtils.js
- Reduced calls to isEmptySTringOrWhiteSpace() by storing values in comparators.
- Comments removed.

CHANGED: Default.js
- createTestDataLargeRandom() fn to build large array to test with.
- getRandomString() added to get a random string.
- sortRows() function now re-applies saved column widths to new first row.

CHANGED: Default.css
- Width changed for reading purposes only.
