### PR TITLE
Callback updated to return all selected rows;

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -35,6 +35,13 @@
         <div id="divContainer">
         </div>
 
+        <br />
+        <br />
+        Callback Feedback:<br />
+        <label id="lblCallbackFeedback"></label>
+        <br />
+        <br />
+
     </div>
     </form>
 </body>

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -6,7 +6,7 @@ What:
 A DynaTable is an HTML table that has a fixed header and a vertically scrolling body.
 The header and body scroll horizontally together.  
 The intention is to have clickable headers to sort the columns, and also to allow highlighted rows.
-A callback facility has been added to detect a click on a row.
+A callback facility has been added to return an array of currently selected rows when a row is selected or deselected.
 
 How:
 

--- a/js/Default.js
+++ b/js/Default.js
@@ -393,11 +393,13 @@ nz.orders.btnApplySort_onClick = function () {
     console.log(prefix + "Exiting");
 }
 
-nz.orders.testCallback = function (row) {
+nz.orders.testCallback = function (arrRows) {
     var prefix = "nz.orders.testCallback() - ";
     console.log(prefix + "Entering");
-    
-    console.log(prefix + "Callback function has been called.");
+
+    var sRows = arrRows.toString();
+    var lblCallbackFeedback = document.getElementById("lblCallbackFeedback");
+    lblCallbackFeedback.innerHTML = sRows;
 
     console.log(prefix + "Exiting");
 }

--- a/js/DynaTable.js
+++ b/js/DynaTable.js
@@ -603,16 +603,18 @@ nz.dynatable.dataCell_onClick = function () {
         row.className = trClassSelected;
     }
 
+    var arrSelectedRows = nz.dynatable.getSelectedRows(table);
+
     // Call the callback with the row clicked on
     if (fc.utils.isValidVar(fnCallback)) {
         if (typeof fnCallback === "function") {
             try {
-                fnCallback(row);
+                fnCallback(arrSelectedRows);
             }
             catch (ex) {
                 var msgException = "Failed during callback for dataCell_onClick event with exception: " + ex.message;
                 nz.dynatable.error(prefix + msgException);
-            }            
+            }
         }
         else {
             nz.dynatable.log(prefix + "Not calling callback function because callback function variable is not of type function.");
@@ -835,6 +837,11 @@ nz.dynatable.applySort = function (sTableId, n, sOrder) {
     nz.dynatable.log(prefix + "Exiting");
 }
 
+// CAUTION: 
+// Sorting functions assume that the table is attached to the document,
+// because they use document.getElementById() to locate the table.
+// If the table is not yet attached, sorts will fail.
+// Attach the dynatable, and then call the sort routine.
 nz.dynatable.applySortByColumnIndex = function (sTableId, n, sOrder) {
     var prefix = "nz.dynatable.applySortByColumnIndex() - ";
     nz.dynatable.log(prefix + "Entering");
@@ -862,6 +869,11 @@ nz.dynatable.applySortByColumnIndex = function (sTableId, n, sOrder) {
     nz.dynatable.log(prefix + "Exiting");
 }
 
+// CAUTION: 
+// Sorting functions assume that the table is attached to the document,
+// because they use document.getElementById() to locate the table.
+// If the table is not yet attached, sorts will fail.
+// Attach the dynatable, and then call the sort routine.
 nz.dynatable.applySortByColumnName = function (sTableId, sColName, sOrder) {
     var prefix = "nz.dynatable.applySortByColumnName() - ";
     nz.dynatable.log(prefix + "Entering");
@@ -1219,6 +1231,7 @@ nz.dynatable.getIndexByColName = function (sTableId, sColumnName) {
     // We're passed a header table, we return a zero-based index for the 
     // corresponding column, or -1 for failure.
     var tableHeader = nz.dynatable.getTableHeader(sTableId);
+
     var row = tableHeader.rows[0];
     for (var i = 0; i < row.cells.length; ++i) {
         var header = fc.utils.textContent(row.cells[i]);


### PR DESCRIPTION
CHANGED: DynaTable.js
 - dataCell_onClick() now calls the callback function with the currently selected rows.
 - Caution comments added regarding when sort functions should be called.

CHANGED: Default.aspx
 - Added html for feedback.

CHANGED: Default.js
 - testCallback() now accepts an array of rows and attempts to crudely display them as a comma list, and fails.

CHANGED: Readme.MD
 - Updated to reflect changes.